### PR TITLE
fix: allocate char* based on size of PROJECT_VERSION

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -133,8 +133,9 @@ class ProjectUpdateTrigger : public Trigger<std::string>, public Component {
   void setup() override {
     uint32_t hash = fnv1_hash(ESPHOME_PROJECT_NAME);
     ESPPreferenceObject pref = global_preferences->make_preference<char[30]>(hash, true);
-    char previous_version[30];
-    char current_version[30] = ESPHOME_PROJECT_VERSION;
+    uint32_t project_version_size = sizeof(ESPHOME_PROJECT_VERSION);
+    char previous_version[project_version_size];
+    char current_version[project_version_size] = ESPHOME_PROJECT_VERSION;
     if (pref.load(&previous_version)) {
       int cmp = strcmp(previous_version, current_version);
       if (cmp < 0) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Attempt at a fix for issue introduced in esphome 2024.3.0 when PROJECT_VERSION > 30 characters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/5629>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
substitutions:
  project_version: "0123456789012345678901234567890123456789"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
